### PR TITLE
Added register_shutdown_function in example

### DIFF
--- a/example.php
+++ b/example.php
@@ -16,4 +16,8 @@ session_set_save_handler(array($session, 'open'),
                          array($session, 'write'),
                          array($session, 'destroy'),
                          array($session, 'gc'));
+
+// The following prevents unexpected effects when using objects as save handlers.
+register_shutdown_function('session_write_close');
+
 session_start();


### PR DESCRIPTION
Added `register_shutdown_function()` to prevent unexpected behavior on php versions less than 5.4.0.

Explanation taken from php website:

> Warning: When using objects as session save handlers, it is important to register the shutdown function with PHP to avoid unexpected side-effects from the way PHP internally destroys objects on shutdown and may prevent the write and close from being called. Typically you should register 'session_write_close' using the register_shutdown_function() function.
